### PR TITLE
Update model to always cast selects to int

### DIFF
--- a/src/app/Models/Tutorial.php
+++ b/src/app/Models/Tutorial.php
@@ -10,6 +10,11 @@ class Tutorial extends Model
     protected $fillable = [
         'permission_id', 'element', 'title', 'content', 'placement', 'order_index',
     ];
+    
+    protected $casts = [
+      'permission_id' => 'integer',
+      'placement' => 'integer',
+    ];
 
     public function permission()
     {

--- a/src/app/Models/Tutorial.php
+++ b/src/app/Models/Tutorial.php
@@ -10,7 +10,7 @@ class Tutorial extends Model
     protected $fillable = [
         'permission_id', 'element', 'title', 'content', 'placement', 'order_index',
     ];
-    
+
     protected $casts = [
       'permission_id' => 'integer',
       'placement' => 'integer',


### PR DESCRIPTION
Some database drivers implicitly convert (non-primary?) keys to string.

This broke the selectors

BEFORE:
![image](https://user-images.githubusercontent.com/932193/43766308-682c4650-9a32-11e8-8b1d-2df4375af8e4.png)
AFTER:
![image](https://user-images.githubusercontent.com/932193/43766358-80e2d59c-9a32-11e8-989b-a12b0ab8610f.png)
